### PR TITLE
Update prost to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
  "geojson",
  "js-sys",
  "num-traits",
- "prost 0.13.5",
+ "prost",
  "prost-build",
  "serde",
  "serde-wasm-bindgen",
@@ -480,22 +480,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -510,24 +500,11 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "regex",
  "syn",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -549,7 +526,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ protoc-generated = ["prost-build"]
 thiserror = { version = "2.0", default-features = false }
 geo-types = { version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-prost = { version = "0.13", default-features = false, features = ["prost-derive", "std"] }
+prost = { version = "0.14" }
 wasm-bindgen = { version = "0.2", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 js-sys = { version = "0.3", optional = true }
@@ -32,7 +32,6 @@ serde_json = { version = "1.0", optional = true }
 [dev-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-prost = { version = "0.13.5" } # for testing we need default-features to be enabled
 
 [build-dependencies]
 prost-build = { version = "0.14.3", optional = true }


### PR DESCRIPTION
Hi everyone 👋 

I saw that mvt-reader is currently using two different versions of `prost`, which also carried into our own project. So I wanted to open this PR to use `prost` 0.14 to unify the versions.

This also means that we can remove the dev-dependency because the features seem to have been simplified, "derive" and "std" are now default features.